### PR TITLE
Update examples to v5.4.0

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -20,7 +20,7 @@ There is a debug option which produces diagnostic information. This information 
 
 ```
 - name: Version
-  uses: paulhatch/semantic-version@v5.2.1
+  uses: paulhatch/semantic-version@v5.4.0
   id: version
   with:
     tag_prefix: ""

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ it will be given the new version if the build were to be retriggered, for exampl
 <!-- start usage -->
 
 ```yaml
-- uses: paulhatch/semantic-version@v5.3.0
+- uses: paulhatch/semantic-version@v5.4.0
   with:
     # The prefix to use to identify tags
     tag_prefix: "v"
@@ -156,12 +156,12 @@ like `v1.2.3+0-db` could be configured like this:
 ```yaml
 - name: Application Version
   id: version
-  uses: paulhatch/semantic-version@v5.3.0
+  uses: paulhatch/semantic-version@v5.4.0
   with:
     change_path: "src/service"
 - name: Database Version
   id: db-version
-  uses: paulhatch/semantic-version@v5.3.0
+  uses: paulhatch/semantic-version@v5.4.0
   with:
     major_pattern: "(MAJOR-DB)"
     minor_pattern: "(MINOR-DB)"


### PR DESCRIPTION
Updates version numbers in examples so that people who copy / paste code will get the latest version of node and no warnings.