### PR TITLE
Added: test case for https://github.com/PaulHatch/semantic-version/is…

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -88,7 +88,7 @@ If you are not able to provide a test case, it is still very helpful to provide 
 
 ## Forking the Project
 
-If want to do something that does not fit with the project goals, particually if you want to include information from an outside system, it is probably best to fork the project and create your own action. One of the goals of this project starting in 5.0.0 is to be easy to fork and customize, and to that end the action has been broken into individual providers than can be replaced. All providers have been implemented using async calls specifically to support calls to external systems.
+If want to do something that does not fit with the project goals, particularly if you want to include information from an outside system, it is probably best to fork the project and create your own action. One of the goals of this project starting in 5.0.0 is to be easy to fork and customize, and to that end the action has been broken into individual providers than can be replaced. All providers have been implemented using async calls specifically to support calls to external systems.
 
 The steps of this action are:
 
@@ -98,7 +98,7 @@ The steps of this action are:
 - Classify the release
 
 Additionally a few formatter provide modular behavior to these step:
-- A tag formmater is used to parse and format the version number
+- A tag formatter is used to parse and format the version number
 - A version formatter is used to format output version string
 - A user formatter is used to format the user information in the output (JSON and CSV are provided in the default implementation)
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1144,3 +1144,35 @@ test('Prerelease mode does not increment to 1.x.x', async () => {
     expect(result.formattedVersion).toBe('1.1.0-prerelease.1');
     expect(result.isTagged).toBe(true);
 }, timeout);
+
+test('Versioning from branch always ignores major commit pattern', async () => {
+    const repo = createTestRepo({
+        versionFromBranch: true,
+        majorPattern: "(MAJOR)"
+    });
+
+    repo.makeCommit('Initial Commit');
+    repo.exec("git checkout -b release/v3.2");
+    repo.makeCommit(`(MAJOR) Second Commit`);
+
+    const result = await repo.runAction();
+
+    expect(result.formattedVersion).toBe('3.2.1+1');
+
+}, timeout);
+
+test('Versioning from branch always ignores minor commit pattern', async () => {
+    const repo = createTestRepo({
+        versionFromBranch: true,
+        minorPattern: "(MINOR)"
+    });
+
+    repo.makeCommit('Initial Commit');
+    repo.exec("git checkout -b release/v3.2");
+    repo.makeCommit(`(MINOR) Second Commit`);
+
+    const result = await repo.runAction();
+
+    expect(result.formattedVersion).toBe('3.2.1+1');
+
+}, timeout);


### PR DESCRIPTION
…sues/179

Have some minor spelling mistakes also whilst checking the contributing docs.

These test cases demonstrate the issue described in https://github.com/PaulHatch/semantic-version/issues/179

The test cases demonstrate the conflict of expectation when using the verion_from_branch functionality. If someone mistakenly has a matching sting in their commits, the reult from the following tests are: 

```
● Versioning from branch always ignores major commit pattern

    expect(received).toBe(expected) // Object.is equality

    Expected: "3.2.1+1"
    Received: "4.0.0+0"

      1158 |     const result = await repo.runAction();
      1159 |
    > 1160 |     expect(result.formattedVersion).toBe('3.2.1+1');
           |                                     ^
      1161 |
      1162 | }, timeout);
      1163 |

      at src/main.test.ts:1160:37
      at fulfilled (src/main.test.ts:28:58)

  ● Versioning from branch always ignores minor commit pattern

    expect(received).toBe(expected) // Object.is equality

    Expected: "3.2.1+1"
    Received: "3.3.0+0"

      1174 |     const result = await repo.runAction();
      1175 |
    > 1176 |     expect(result.formattedVersion).toBe('3.2.1+1');
           |                                     ^
      1177 |
      1178 | }, timeout);

      at src/main.test.ts:1176:37
      at fulfilled (src/main.test.ts:28:58)
```

I did try and figure out where this would be fixed in the source code of the action, admittedly I got a bit lost in the `DefaultLastReleaseResolver.ResolveAsync` function. I'm also not sure @PaulHatch what you would like to do with this, or if it is intentional. So I'll await and see what you think, admittedly you may be better at producing a patch for this, seeing as I did get a bit lost in figuring out what the fix should be. 