### PR TITLE
chore!: update to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version-file: package.json
           cache: "npm"
 
       - name: Install dependencies
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version-file: package.json
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 

--- a/action.yml
+++ b/action.yml
@@ -105,5 +105,5 @@ outputs:
     description: "Diagnostic information, if debug is enabled"
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "@semanticversion/cli",
-      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.2",
@@ -14,11 +13,11 @@
         "commander": "^14.0.2"
       },
       "bin": {
-        "git-semantic-version": "lib/cli.js",
-        "git-sv": "lib/cli.js"
+        "semver": "lib/cli.js",
+        "sv": "lib/cli.js"
       },
       "devDependencies": {
-        "@types/node": "^22.19.7",
+        "@types/node": "^24.1.0",
         "@vercel/ncc": "^0.38.4",
         "jest": "^30.2.0",
         "js-yaml": "^4.1.1",
@@ -27,7 +26,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {
@@ -96,7 +95,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1454,13 +1452,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-      "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -2003,7 +2001,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2776,7 +2773,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -3949,7 +3945,6 @@
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4397,7 +4392,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4433,9 +4427,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lib/**/*.d.ts"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   },
   "scripts": {
     "prepublishOnly": "npm run build",
@@ -46,7 +46,7 @@
     "commander": "^14.0.2"
   },
   "devDependencies": {
-    "@types/node": "^22.19.7",
+    "@types/node": "^24.1.0",
     "@vercel/ncc": "^0.38.4",
     "jest": "^30.2.0",
     "js-yaml": "^4.1.1",


### PR DESCRIPTION
This updates the action to build, test, and execute in Node 24. As mentioned in #187, Node 20 has been deprecated for actions so this change is necessary.

Resolves #187